### PR TITLE
Allow NN files to be imported directly into a project (rather than producing a library/framework)

### DIFF
--- a/lib/ios/native-navigation/ReactNavigation.swift
+++ b/lib/ios/native-navigation/ReactNavigation.swift
@@ -6,7 +6,9 @@
 //  Copyright © 2016 Airbnb. All rights reserved.
 //
 
-import React
+#if !NN_NO_COCOAPODS
+  import React
+#endif
 import UIKit
 
 private let VERSION: Int = 2

--- a/lib/ios/native-navigation/ReactNavigationCoordinator.h
+++ b/lib/ios/native-navigation/ReactNavigationCoordinator.h
@@ -1,0 +1,5 @@
+//
+//  ReactNavigationCoordinatorDelegate.h
+//
+
+@protocol ReactNavigationCoordinatorDelegate;

--- a/lib/ios/native-navigation/ReactNavigationCoordinator.swift
+++ b/lib/ios/native-navigation/ReactNavigationCoordinator.swift
@@ -6,7 +6,9 @@
 //  Copyright © 2016 Airbnb. All rights reserved.
 //
 
-import React
+#if !NN_NO_COCOAPODS
+  import React
+#endif
 import UIKit
 
 @objc public protocol ReactNavigationCoordinatorDelegate {

--- a/lib/ios/native-navigation/ReactNavigationImplementation.swift
+++ b/lib/ios/native-navigation/ReactNavigationImplementation.swift
@@ -8,8 +8,9 @@
 
 import Foundation
 import UIKit
-import React
-
+#if !NN_NO_COCOAPODS
+  import React
+#endif
 
 @objc public protocol ReactNavigationImplementation: class {
 

--- a/lib/ios/native-navigation/ReactTabBarController.swift
+++ b/lib/ios/native-navigation/ReactTabBarController.swift
@@ -8,7 +8,9 @@
 
 import Foundation
 import UIKit
-import React
+#if !NN_NO_COCOAPODS
+  import React
+#endif
 
 open class ReactTabBarController: UITabBarController {
 

--- a/lib/ios/native-navigation/ReactViewController.swift
+++ b/lib/ios/native-navigation/ReactViewController.swift
@@ -6,8 +6,10 @@
 //  Copyright © 2016 Airbnb. All rights reserved.
 //
 
-import React
 import UIKit
+#if !NN_NO_COCOAPODS
+  import React
+#endif
 
 // MARK: Public
 

--- a/lib/ios/native-navigation/SharedElementGroupManager.swift
+++ b/lib/ios/native-navigation/SharedElementGroupManager.swift
@@ -6,7 +6,10 @@
 //  Copyright © 2016 Airbnb. All rights reserved.
 //
 
-import React
+import UIKit
+#if !NN_NO_COCOAPODS
+  import React
+#endif
 
 // MARK: - SharedElementGroup
 

--- a/lib/ios/native-navigation/SharedElementManager.swift
+++ b/lib/ios/native-navigation/SharedElementManager.swift
@@ -6,8 +6,10 @@
 //  Copyright © 2016 Airbnb. All rights reserved.
 //
 
-import React
 import UIKit
+#if !NN_NO_COCOAPODS
+  import React
+#endif
 
 // MARK: - SharedElement
 

--- a/lib/ios/native-navigation/TabBarViewManager.swift
+++ b/lib/ios/native-navigation/TabBarViewManager.swift
@@ -6,7 +6,10 @@
 //  Copyright © 2016 Airbnb. All rights reserved.
 //
 
-import React
+import UIKit
+#if !NN_NO_COCOAPODS
+  import React
+#endif
 
 final class TabBar: RCTView {
 

--- a/lib/ios/native-navigation/TabViewManager.swift
+++ b/lib/ios/native-navigation/TabViewManager.swift
@@ -6,7 +6,10 @@
 //  Copyright © 2016 Airbnb. All rights reserved.
 //
 
-import React
+import UIKit;
+#if !NN_NO_COCOAPODS
+    import React
+#endif
 
 // MARK: - TabView
 

--- a/lib/ios/native-navigation/UIBarButtonItem+addAction.swift
+++ b/lib/ios/native-navigation/UIBarButtonItem+addAction.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-
 public class ClosureWrapper : NSObject {
   let _callback : (Void) -> Void
   init(callback : @escaping (Void) -> Void) {


### PR DESCRIPTION
- Removes 'import React' statements when NN_NO_COCOAPODS flag is set (imports must be supplied in project by a bridging header)
- Adds forward declaration for ReactNavigationCoordinatorDelegate protocol

This allows us to build without Cocoapods, by including the files directly from the `node_modules` folder in our project.  The `NN_NO_COCOAPODS` swift compilation flag must be set in order for this to work (otherwise it will attempt and fail to import React).

A bridging header with the following imports must also be supplied in the host project:
```
#import <React/RCTRootView.h>
#import <React/RCTView.h>
#import <React/RCTViewManager.h>
```

**Note:**
We can remove the ugly `NN_NO_COCOAPODS` flag, and replace it with `canImport` as soon as we upgrade to XCode 9.3 + Swift 4.1.  

