### PR TITLE
Fix a race condition that meant ReactNativeFragment.onAttachWithReactContext never got called in some cases

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
@@ -125,7 +125,7 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
     if (!isSuccessfullyInitialized()) {
       // TODO(lmr): need a different way of doing this
       // TODO(lmr): move to utils
-      reactInstanceManager.addReactInstanceEventListener(
+      reactNavigationCoordinator.addInitializationListener(
               new ReactInstanceManager.ReactInstanceEventListener() {
                 @Override
                 public void onReactContextInitialized(ReactContext context) {
@@ -310,6 +310,7 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
     super.onPause();
     emitEvent(ON_DISAPPEAR, null);
   }
+
   @Override
   public void onResume() {
     super.onResume();


### PR DESCRIPTION
This fixes an issue that became apparent on devices running on Android 8/8.1.  The app would launch and show a blank screen sometimes (not every time - normally reproducable the first time the app is opened after install/data clear).

Essentially, this was due to a race condition, that meant `ReactNativeFragment.onAttachWithReactContext()` would never get called. 

The order of events in a successful run was:
- `ReactInstanceManager.addReactInstanceEventListener()` (Add listener #1 to update `isInitialized` flag)
- `ReactInstanceManager.isInitialized() -> false`
- `ReactInstanceManager.addReactInstanceEventListener()` (Add listener #2 to call `ReactNativeFragment.onAttachWithReactContext()`)
- `ReactInstanceManager.setupReactContext()`
- `[Async Message Post] ReactInstanceManager.mReactInstanceEventListeners.onReactContextInitialized()`
- `[Async Message Receive]` - Both listeners are called - updates `isInitialized` flag and calls `ReactNativeFragment.onAttachWithReactContext()`

In an unsuccessful run:

- `ReactInstanceManager.addReactInstanceEventListener()` (Add listener #1 to update `isInitialized` flag)
- `ReactInstanceManager.setupReactContext()`
- `[Async Message Post] ReactInstanceManager.mReactInstanceEventListeners.onReactContextInitialized()`
- `ReactInstanceManager.isInitialized() -> false` (Still false, because the Runnable is still on the Handler queue)
- `ReactInstanceManager.addReactInstanceEventListener()` (Add listener #2 to call `ReactNativeFragment.onAttachWithReactContext()` - but it's too late)
- `[Async Message Receive]` - Only the first listener is called - updates `isInitialized` flag
- ReactNativeFragment.onAttachWithReactContext() never gets called, because it was attached after the listener update message was already posted

With this change, listener #2 is attached to listener #1, so it's guaranteed to be called whenever the `isInitialized` flag is updated.