### PR TITLE
Fix Android crash when user navigates and presses back button mid-navigation

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/BackStack.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/BackStack.java
@@ -58,6 +58,10 @@ class BackStack {
         return fragments.size();
     }
 
+    boolean isEmpty() {
+        return getSize() == 0;
+    }
+
     @Override
     public String toString() {
         return "BackStack{" + ", tag='" + tag +


### PR DESCRIPTION
When a user navigates forward, and before the transition is complete, presses the hardware back button twice, then the app crashes. 

This prevents that in a quick and easy way, by ensuring the back button does nothing if there is no back stack