### PR TITLE
Fix onDisappear event not sent when pushing on Android

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
@@ -337,7 +337,7 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
     @Override
     public void onPause() {
         super.onPause();
-        emitEvent(ON_DISAPPEAR, null);
+        this.emitOnDisappear();
     }
 
     @Override
@@ -346,6 +346,10 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
         Log.d(TAG, "onResume");
         updateBarHeightIfNeeded();
         emitOnAppear();
+    }
+
+    public void emitOnDisappear() {
+        emitEvent(ON_DISAPPEAR, null);
     }
 
     public void emitOnAppear() {

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
@@ -125,6 +125,10 @@ public class ScreenCoordinator {
             .commit();
     bsi.pushFragment(fragment);
     Log.d(TAG, toString());
+
+    if (currentFragment instanceof ReactNativeFragment) {
+      ((ReactNativeFragment) currentFragment).emitOnDisappear();
+    }
   }
 
   public void resetTo(Fragment fragment, @Nullable Bundle options) {


### PR DESCRIPTION
Since we're adding fragment, onPause would of course not be called on the previous fragment.
To mimic iOS behavior of onDisappear, when push a screen, we emit onDisappear for the previous one