### PR TITLE
Allowing to present from a non ReactViewController

### DIFF
--- a/lib/ios/native-navigation/ReactNavigation.swift
+++ b/lib/ios/native-navigation/ReactNavigation.swift
@@ -99,33 +99,39 @@ class ReactNavigation: NSObject {
     }
   }
   
-  func present(_ screenName: String, withProps props: [String: AnyObject], options: [String: AnyObject], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-    print("present \(screenName)")
+func present(_ screenName: String,
+                 withProps props: [String: AnyObject],
+                 options: [String: AnyObject],
+                 resolve: @escaping RCTPromiseResolveBlock,
+                 reject: @escaping RCTPromiseRejectBlock) {
+    debugPrint("pushNative: \(screenName)")
     DispatchQueue.main.async {
-      guard let nav = self.coordinator.topNavigationController() else { return }
-      guard let current = self.coordinator.topViewController() as? ReactViewController else {
-        print("Called present() when topViewController() isn't a ReactViewController")
-        return
-      }
-      let animated = (options["animated"] as? Bool) ?? true
-      let presented = ReactViewController(moduleName: screenName, props: props)
-
-      var makeTransition: (() -> ReactSharedElementTransition)? = nil
-
-      if let transitionGroup = options["transitionGroup"] as? String {
-        makeTransition = {
-          return ReactSharedElementTransition(
-            transitionGroup: transitionGroup,
-            fromViewController: current,
-            toViewController: presented as ReactAnimationToContentVendor,
-            style: ReactSharedElementTransition.makeDefaultStyle(options),
-            options: [:]
-          )
+        guard let nav = self.coordinator.topNavigationController() else { return }
+        
+        let animated = (options["animated"] as? Bool) ?? true
+        let presented = ReactViewController(moduleName: screenName, props: props)
+        
+        var makeTransition: (() -> ReactSharedElementTransition)? = nil
+        
+        if let current = self.coordinator.topViewController() as? ReactViewController,
+            let transitionGroup = options["transitionGroup"] as? String {
+            makeTransition = {
+                return ReactSharedElementTransition(
+                    transitionGroup: transitionGroup,
+                    fromViewController: current,
+                    toViewController: presented as ReactAnimationToContentVendor,
+                    style: ReactSharedElementTransition.makeDefaultStyle(options),
+                    options: [:]
+                )
+            }
         }
-      }
-
-      self.coordinator.registerFlow(presented, resolve: resolve, reject: reject)
-      nav.presentReactViewController(presented, animated: animated, completion: nil, presentationStyle: self.modalPresentationStyle(from: options), makeTransition: makeTransition)
+        
+        self.coordinator.registerFlow(presented, resolve: resolve, reject: reject)
+        nav.presentReactViewController(presented,
+                                       animated: animated,
+                                       completion: nil,
+                                       presentationStyle: self.modalPresentationStyle(from: options),
+                                       makeTransition: makeTransition)
     }
   }
   


### PR DESCRIPTION
**the context**
In iOS when we're trying to present modally from an UIViewController which it doesn't inherit from ReactViewController.

**the problem**
The ReactNavigation will check if the current presenting UIViewController it's an instance of type ReactViewController. If not it will skip that presentation.

**the solution**
By adding a proper check in the ReactNavigation we will able to present modally a UIViewController and also respect the Viewing stack state save by ReactNavigation.