### PR TITLE
remove uses-sdk from AndroidManifest.xml

### DIFF
--- a/lib/android/src/main/AndroidManifest.xml
+++ b/lib/android/src/main/AndroidManifest.xml
@@ -3,9 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-sdk
-          android:minSdkVersion="16"
-          android:targetSdkVersion="24" />
   <application>
     <activity
       android:name="com.airbnb.android.react.navigation.ReactNativeActivity"


### PR DESCRIPTION
Android Gradle plugin 3.2.1 will throw an error if uses-sdk with minSdkVersion is present inside AndroidManifest.xml.

Removing this tag does not do any harm because minSdk and targetSdk will be taken from the build.gradle anyway.